### PR TITLE
Add events over time panel migration

### DIFF
--- a/cmd/cli/dashboards-migrator.go
+++ b/cmd/cli/dashboards-migrator.go
@@ -43,8 +43,8 @@ func CLIStart() error {
 		return fmt.Errorf("creating output file: '%s' failed: %v", config.OutputPath, err)
 	}
 
-	defer outputWriter.Flush()
 	defer outputWriter.Close()
+	defer outputWriter.Flush()
 
 	for _, savedObject := range lm4dashboard {
 		rawSavedObject, err := json.Marshal(savedObject)

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,13 @@ module github.com/logmanager-oss/dashboards-migrator
 
 go 1.24.1
 
-require github.com/google/uuid v1.6.0
+require (
+	github.com/google/uuid v1.6.0
+	github.com/stretchr/testify v1.10.0
+)
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,11 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
+github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/internal/migrator/eventsOverTime.go
+++ b/internal/migrator/eventsOverTime.go
@@ -1,0 +1,27 @@
+package migrator
+
+import (
+	"github.com/logmanager-oss/dashboards-migrator/internal/objects/lm4/objects"
+	vistypes "github.com/logmanager-oss/dashboards-migrator/internal/objects/lm4/visTypes"
+)
+
+func (m *Migrator) migrateEventsOverTimePanel(title string) (*objects.VisualizationObject, error) {
+	visualizationObject := objects.NewVisualisation(&vistypes.EventsOverTime{})
+	visualizationObject.SetTitle(title)
+	visualizationObject.SetSearch(visualizationObject.Type.GetSearch())
+	visualizationObject.SetVisStateAggs(visualizationObject.Type.GetAggs())
+
+	m.dashboardObject.SetAndAppendGridData(
+		objects.EventsOverTimeVisWidth,
+		objects.DefaultVisHeight,
+		visualizationObject.ID,
+		visualizationObject.Title,
+	)
+
+	m.dashboardObject.SetAndAppendReference(
+		visualizationObject.ID,
+		visualizationObject.RefType,
+	)
+
+	return visualizationObject, nil
+}

--- a/internal/migrator/eventsOverTime_test.go
+++ b/internal/migrator/eventsOverTime_test.go
@@ -1,0 +1,59 @@
+package migrator
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/logmanager-oss/dashboards-migrator/internal/objects/lm4"
+)
+
+func TestMigrator_migrateEventsOverTimePanel(t *testing.T) {
+	tests := []struct {
+		name     string
+		title    string
+		expected string
+	}{
+		{
+			name:     "Test case: migrate events over time panel",
+			title:    "Events Over Time",
+			expected: `{"attributes":{"description":"","kibanaSavedObjectMeta":{"searchSourceJSON":"{\"query\":{\"query\":\"\",\"language\":\"kuery\"},\"filter\":[],\"indexRefName\":\"kibanaSavedObjectMeta.searchSourceJSON.index\"}"},"title":"Events Over Time","uiStateJSON":"{}","version":1,"visState":"{\"title\":\"Events Over Time\",\"type\":\"histogram\",\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"count\",\"schema\":\"metric\",\"params\":{\"field\":\"\",\"orderBy\":\"\",\"order\":\"\",\"size\":0,\"otherBucket\":false,\"otherBucketLabel\":\"\",\"missingBucket\":false,\"missingBucketLabel\":\"\"}},{\"id\":\"2\",\"enabled\":true,\"type\":\"date_histogram\",\"schema\":\"segment\",\"params\":{\"field\":\"@timestamp\",\"orderBy\":\"1\",\"order\":\"desc\",\"size\":100,\"otherBucket\":true,\"otherBucketLabel\":\"Other\",\"missingBucket\":false,\"missingBucketLabel\":\"Missing\"}}],\"params\":{\"type\":\"histogram\",\"grid\":{\"categoryLines\":true,\"valueAxis\":\"ValueAxis-1\"},\"categoryAxes\":[{\"id\":\"CategoryAxis-1\",\"type\":\"category\",\"position\":\"bottom\",\"show\":true,\"style\":{},\"scale\":{\"type\":\"linear\"},\"labels\":{\"show\":true,\"filter\":false,\"truncate\":100},\"title\":{}}],\"valueAxes\":[{\"id\":\"ValueAxis-1\",\"name\":\"LeftAxis-1\",\"type\":\"value\",\"position\":\"left\",\"show\":true,\"style\":{},\"scale\":{\"type\":\"linear\",\"mode\":\"normal\"},\"labels\":{\"show\":true,\"rotate\":0,\"filter\":false,\"truncate\":100},\"title\":{\"text\":\"Count\"}}],\"seriesParams\":[{\"show\":true,\"type\":\"histogram\",\"mode\":\"stacked\",\"data\":{\"label\":\"Count\",\"id\":\"1\"},\"valueAxis\":\"ValueAxis-1\",\"drawLinesBetweenPoints\":true,\"lineWidth\":2,\"showCircles\":true}],\"addTooltip\":true,\"addLegend\":true,\"legendPosition\":\"top\",\"times\":[],\"addTimeMarker\":false,\"labels\":{\"show\":true},\"thresholdLine\":{\"show\":false,\"value\":10,\"width\":1,\"style\":\"full\",\"color\":\"#E7664C\"}}}"},"id":"","migrationVersion":{"visualization":"7.10.0"},"references":[{"id":"","name":"kibanaSavedObjectMeta.searchSourceJSON.index","type":"index-pattern"}],"type":"visualization","updated_at":"0001-01-01T00:00:00Z","version":""}`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			migrator := New()
+
+			actual, err := migrator.migrateEventsOverTimePanel(tt.title)
+			if err != nil {
+				t.Error(err)
+			}
+
+			var expectedSavedObject *lm4.SavedObject
+			err = json.Unmarshal([]byte(tt.expected), &expectedSavedObject)
+			if err != nil {
+				t.Error(err)
+			}
+
+			var expectedVisState *lm4.VisState
+			err = json.Unmarshal([]byte(expectedSavedObject.Attributes.VisState), &expectedVisState)
+			if err != nil {
+				t.Error(err)
+			}
+
+			var expectedSearch *lm4.SearchSourceJSON
+			err = json.Unmarshal([]byte(expectedSavedObject.Attributes.KibanaSavedObjectMeta.SearchSourceJSON), &expectedSearch)
+			if err != nil {
+				t.Error(err)
+			}
+
+			expectedSavedObject.Attributes.VisState = ""
+			expectedSavedObject.Attributes.KibanaSavedObjectMeta.SearchSourceJSON = ""
+
+			assert.Equal(t, expectedSavedObject, actual.SavedObject)
+			assert.Equal(t, expectedVisState, actual.VisState)
+			assert.Equal(t, expectedSearch, actual.Search)
+		})
+	}
+}

--- a/internal/migrator/migrator.go
+++ b/internal/migrator/migrator.go
@@ -1,18 +1,55 @@
 package migrator
 
 import (
+	"fmt"
+
 	"github.com/logmanager-oss/dashboards-migrator/internal/objects/lm3"
 	"github.com/logmanager-oss/dashboards-migrator/internal/objects/lm4"
+	"github.com/logmanager-oss/dashboards-migrator/internal/objects/lm4/objects"
 )
 
 type Migrator struct {
-	savedObjects []lm4.SavedObject
+	savedObjects    []lm4.SavedObject
+	dashboardObject *objects.DashboardObject
 }
 
 func New() *Migrator {
-	return &Migrator{}
+	return &Migrator{
+		dashboardObject: objects.NewDashboard(),
+	}
 }
 
-func (m *Migrator) Migrate(_ lm3.Dashboard) ([]lm4.SavedObject, error) {
+func (m *Migrator) Migrate(lm3Dashboard lm3.Dashboard) ([]lm4.SavedObject, error) {
+	for _, row := range lm3Dashboard.Rows {
+		for _, panel := range row.Panels {
+			if panel.Type == "histogram" {
+				if panel.Queries.Mode == "all" {
+					newVisualizationObject, err := m.migrateEventsOverTimePanel(panel.Title)
+					if err != nil {
+						return nil, fmt.Errorf("migrating %s panel: %v", panel.Title, err)
+					}
+
+					finalVisualizationObject, err := newVisualizationObject.GetFinalVisualizationObject()
+					if err != nil {
+						return nil, err
+					}
+
+					m.appendSavedObjectToOutput(finalVisualizationObject)
+				}
+			}
+		}
+	}
+
+	finalDashboardObject, err := m.dashboardObject.GetFinalDashboardObject()
+	if err != nil {
+		return nil, err
+	}
+
+	m.appendSavedObjectToOutput(finalDashboardObject)
+
 	return m.savedObjects, nil
+}
+
+func (m *Migrator) appendSavedObjectToOutput(savedObject *lm4.SavedObject) {
+	m.savedObjects = append(m.savedObjects, *savedObject)
 }

--- a/internal/objects/lm4/objects/constants.go
+++ b/internal/objects/lm4/objects/constants.go
@@ -1,0 +1,6 @@
+package objects
+
+const (
+	EventsOverTimeVisWidth = 48
+	DefaultVisHeight       = 15
+)

--- a/internal/objects/lm4/visTypes/eventsOverTime.go
+++ b/internal/objects/lm4/visTypes/eventsOverTime.go
@@ -1,0 +1,43 @@
+package vistypes
+
+import (
+	"github.com/logmanager-oss/dashboards-migrator/internal/objects/lm4"
+	"github.com/logmanager-oss/dashboards-migrator/internal/objects/lm4/defaults"
+)
+
+type EventsOverTime struct{}
+
+func (e *EventsOverTime) GetAggs() []lm4.VisStateAggs {
+	return []lm4.VisStateAggs{
+		{
+			ID:      "1",
+			Enabled: true,
+			Type:    "count",
+			Params:  lm4.VisStateAggsParams{},
+			Schema:  "metric",
+		},
+		{
+			ID:      "2",
+			Enabled: true,
+			Type:    "date_histogram",
+			Schema:  "segment",
+			Params: lm4.VisStateAggsParams{
+				Field:              "@timestamp",
+				OrderBy:            "1",
+				Order:              "desc",
+				Size:               100,
+				OtherBucket:        true,
+				OtherBucketLabel:   "Other",
+				MissingBucket:      false,
+				MissingBucketLabel: "Missing",
+			},
+		},
+	}
+}
+
+func (e *EventsOverTime) GetSearch() *lm4.SearchSourceJSON {
+	search := defaults.GetDefaultSearch()
+	search.IndexRefName = "kibanaSavedObjectMeta.searchSourceJSON.index"
+
+	return search
+}


### PR DESCRIPTION
Added first migration of Events Over Time panel:

- LM4 Dashboard Object is initialised during migration start
- LM3 Dashboard Object is loaded and iterated over
- Once panel type is detected (in this case standard Events Over Type) generic visualisation object is initialised with concrete LM4 type (Events Over Time in this case)
- Title, VisAggs(in other words visualisation settings) and search is set
- Grid (position of visualisation in the dashboard) is calculated and set in LM4 Dashboard Object 
- Visualisation reference is set in LM4 Dashboard Object 
- Both objects (visualisation and dashboard) are finalised (as explained in previous MRs) and appended to the Migrator output