### PR TITLE
fix: grouped queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ Usage of ./dashboards-migrator:
         Path to output file containing LM4 dashboard (Mandatory)
 ```
 
+If you used `ip` flag you need to make sure **before** importing your migrated dashboard that related index and index-pattern exists.
+
 **Examples:**
 
 1. Read LM3 dashboard from `log-overview.json` file, set index-pattern to `lm-*` and output migration results to `log-overview.ndjson`

--- a/cmd/config/config.go
+++ b/cmd/config/config.go
@@ -82,8 +82,10 @@ func (c *Config) validateOutputPath(flagValue string) error {
 }
 
 func (c *Config) validateIndexPattern(flagValue string) error {
-	if !strings.HasPrefix(flagValue, "lm-") {
-		return fmt.Errorf("index-pattern must begin with \"lm-\" prefix")
+	if flagValue != "" {
+		if !strings.HasPrefix(flagValue, "lm-") {
+			return fmt.Errorf("index-pattern must begin with \"lm-\" prefix")
+		}
 	}
 
 	return nil

--- a/internal/migrator/visualization/visualization.go
+++ b/internal/migrator/visualization/visualization.go
@@ -62,10 +62,16 @@ func (vis *LM4Visualization) migrateQueries(lm3queries []lm3.Query) {
 			continue
 		}
 
-		queries = append(queries, query.Query)
+		queries = append(queries, fixGroupedValues(query.Query))
 	}
 
 	vis.Search.Query.Query = strings.Join(queries, " or ")
+}
+
+// fixGroupedValues inserts OR between space-separated quoted values in a Lucene query.
+// e.g. field:("val1" "val2") becomes field:("val1" OR "val2")
+func fixGroupedValues(query string) string {
+	return strings.ReplaceAll(query, `" "`, `" OR "`)
 }
 
 func (vis *LM4Visualization) migrateConfig(field string, size int, columns []string, visualizationType objects.VisType) {

--- a/internal/migrator/visualization/visualization_test.go
+++ b/internal/migrator/visualization/visualization_test.go
@@ -12,6 +12,81 @@ import (
 	"github.com/logmanager-oss/dashboards-migrator/internal/types/lm4"
 )
 
+func TestMigrateQueries_GroupedValues(t *testing.T) {
+	tests := []struct {
+		name     string
+		queries  []lm3.Query
+		expected string
+	}{
+		{
+			name: "single query with space-separated grouped values",
+			queries: []lm3.Query{
+				{
+					ID:     0,
+					Type:   "lucene",
+					Query:  `msg.event_type:("Audit_Event" "Audit Event")`,
+					Enable: true,
+				},
+			},
+			expected: `msg.event_type:("Audit_Event" OR "Audit Event")`,
+		},
+		{
+			name: "multiple queries with space-separated grouped values",
+			queries: []lm3.Query{
+				{
+					ID:     0,
+					Type:   "lucene",
+					Query:  `msg.event_type:("Audit_Event" "Audit Event")`,
+					Enable: true,
+				},
+				{
+					ID:     1,
+					Type:   "lucene",
+					Query:  `msg.event_type:("Threat_Event" "Threat Event")`,
+					Enable: true,
+				},
+			},
+			expected: `msg.event_type:("Audit_Event" OR "Audit Event") or msg.event_type:("Threat_Event" OR "Threat Event")`,
+		},
+		{
+			name: "query with NOT and space-separated grouped values",
+			queries: []lm3.Query{
+				{
+					ID:     0,
+					Type:   "lucene",
+					Query:  `NOT msg.event_type:("Audit_Event" "Audit Event" "Threat_Event" "Threat Event")`,
+					Enable: true,
+				},
+			},
+			expected: `NOT msg.event_type:("Audit_Event" OR "Audit Event" OR "Threat_Event" OR "Threat Event")`,
+		},
+		{
+			name: "query without grouped values is unchanged",
+			queries: []lm3.Query{
+				{
+					ID:     0,
+					Type:   "lucene",
+					Query:  "meta.tags:loginsuccess",
+					Enable: true,
+				},
+			},
+			expected: "meta.tags:loginsuccess",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			vis := &LM4Visualization{
+				Search: objects.GetDefaultSearchObject(true),
+			}
+
+			vis.migrateQueries(tt.queries)
+
+			assert.Equal(t, tt.expected, vis.Search.Query.Query)
+		})
+	}
+}
+
 func TestMigrator_migrateVisualizations(t *testing.T) {
 	tests := []struct {
 		name              string


### PR DESCRIPTION
Queries defined like this in LM3 `"query": "msg.event_type:(\"Threat_Event\" \"Threat Event\")"` fail to work with LM4.

The fix is to replace space separation with `OR`.